### PR TITLE
Update composer.json to 1.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "errnesto/kirby-plugin-webhooks",
   "description": "Kirby plugin to register custom webhooks based on kirby hooks",
   "type": "kirby-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
It seems like there was a 1.0.1 patch in 2021, but the update was never pushed to composer an I assume that's because the version in the composer.json was never changed?